### PR TITLE
Version 0.8.5 adding keys to skipped attributes adding validation to draft object

### DIFF
--- a/.github/workflows/env.yml
+++ b/.github/workflows/env.yml
@@ -1,0 +1,5 @@
+env:
+  RUBY_VERSION: 2.6.3
+  POSTGRES_USER: postgres
+  POSTGRES_PASSWORD: ""
+  POSTGRES_DB: postgres

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,0 +1,24 @@
+name: Gem Tests
+on: [push,pull_request]
+jobs:
+  rspec-test:
+    name: Rspec
+    runs-on: ubuntu-18.04
+    services:
+      postgres:
+        image: postgres:latest
+        ports:
+        - 5432:5432
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-ruby@v1
+      - name: Install postgres client
+        run: sudo apt-get install libpq-dev
+      - name: Install dependencies
+        run: |
+          gem install bundler
+          bundler install
+      - name: Create Database
+        run: RAILS_ENV=test bundle exec rake -f spec/dummy/Rakefile db:schema:load
+      - name: Run Tests
+        run: bundler exec rake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.8.1.dev
+
+- Enable propagation of exceptions to calling model
+
 ## 0.8.0.dev
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -1,22 +1,12 @@
 # Project status #
 
-🚨 Draftsman is [looking for a new Steward](https://github.com/jmfederico/draftsman/issues/85) 🚨
+Draftsman for spectrum is a fork of a gem (https://github.com/copasetickid/draftsman) with some minor changes to it.
 
-# Draftsman v0.8.1.dev
-
-[![Build Status](https://travis-ci.org/jmfederico/draftsman.svg?branch=master)](https://travis-ci.org/jmfederico/draftsman)
+# Draftsman v0.8.4.dev
 
 Draftsman is a Ruby gem that lets you create draft versions of your database
 records. If you're developing a system in need of simple drafts or a publishing
 approval queue, then Draftsman just might be what you need.
-
--  The largest risk at this time is functionality that assists with publishing
-   or reverting dependencies through associations (for example, "publishing" a
-   child also publishes its parent if it's a new item). We'll be putting this
-   functionality through its paces in the coming months.
--  The RSpec tests are lacking in some areas, so I will be adding to those over
-   time as well. (Unfortunately, this gem was not developed with TDD best
-   practices because it was lifted from PaperTrail and modified from there.)
 
 This gem is inspired by the [Kentouzu][1] gem, which is based heavily on
 [PaperTrail][2]. In fact, much of the structure for this gem emulates PaperTrail
@@ -28,7 +18,6 @@ Sinatra.
 
 -  Provides API for storing drafts of creations, updates, and destroys.
 -  A max of one draft per record (via `belongs_to` association).
--  Does not store drafts for updates that don't change anything.
 -  Allows you to specify attributes (by inclusion or exclusion) that must change
    for a draft to be stored.
 -  Ability to query drafts based on the current drafted item, or query all
@@ -68,13 +57,7 @@ ActiveRecord.
 Add Draftsman to your `Gemfile`.
 
 ```ruby
-gem 'draftsman', '~> 0.7.1'
-```
-
-Or if you want to grab the latest from `master`:
-
-```ruby
-gem 'draftsman', github: 'jmfederico/draftsman'
+gem 'draftsman', git: 'https://github.com/spectrum-md/draftsman.git', branch: 'master'
 ```
 
 Generate a migration which will add a `drafts` table to your database.
@@ -124,7 +107,7 @@ your app with Draftsman will look something like this:
 Add Draftsman to your `Gemfile`.
 
 ```ruby
-gem 'draftsman', github: 'jmfederico/draftsman'
+gem 'draftsman', git: 'https://github.com/spectrum-md/draftsman.git', branch: 'master'
 ```
 
 Generate a migration to add a `drafts` table to your database.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Project status #
 
-🚨 Drfatsman is [looking for a new Steward](https://github.com/jmfederico/draftsman/issues/85) 🚨
+🚨 Draftsman is [looking for a new Steward](https://github.com/jmfederico/draftsman/issues/85) 🚨
 
-# Draftsman v0.8.0.dev
+# Draftsman v0.8.1.dev
 
 [![Build Status](https://travis-ci.org/jmfederico/draftsman.svg?branch=master)](https://travis-ci.org/jmfederico/draftsman)
 

--- a/lib/draftsman/draft.rb
+++ b/lib/draftsman/draft.rb
@@ -1,9 +1,13 @@
+require 'draftsman/validators/draft_object_validator'
+
 class Draftsman::Draft < ActiveRecord::Base
   # Associations
   belongs_to :item, polymorphic: true
 
   # Validations
   validates :event, presence: true
+
+  validates_with Draftsman::Validators::DraftObjectValidator
 
   # Scopes
   # Returns `where` that filters to only `create` drafts.

--- a/lib/draftsman/draft.rb
+++ b/lib/draftsman/draft.rb
@@ -83,7 +83,7 @@ class Draftsman::Draft < ActiveRecord::Base
 
         if association_class.draftable? && association.name != association_class.draft_association_name.to_sym
           dependency = my_item.send(association.name)
-          dependencies << dependency.draft if dependency.present? && dependency.draft? && dependency.draft.create?
+          dependencies << dependency.draft if dependency.present? && dependency.draft? && dependency.draft&.create?
         end
       end
     when :destroy

--- a/lib/draftsman/model.rb
+++ b/lib/draftsman/model.rb
@@ -83,6 +83,8 @@ module Draftsman
 
         draftsman_options[:ignore] << "#{self.draft_association_name}_id"
 
+        draftsman_options[:skip] << ["#{self.draft_association_name}_id", "id"]
+
         draftsman_options[:meta] ||= {}
 
         draftsman_options[:publish_options] ||= { validate: false }

--- a/lib/draftsman/model.rb
+++ b/lib/draftsman/model.rb
@@ -253,7 +253,7 @@ module Draftsman
               id = send(self.class.draft_association_name).id
               self.update_attribute(fk, id)
             else
-              raise ActiveRecord::Rollback and return false
+              raise ActiveRecord::Rollback
             end
           end
         end
@@ -380,7 +380,7 @@ module Draftsman
                       self.save
                     end
                   else
-                    raise ActiveRecord::Rollback and return false
+                    raise ActiveRecord::Rollback
                   end
                 end
               # Otherwise, just save the record.

--- a/lib/draftsman/model.rb
+++ b/lib/draftsman/model.rb
@@ -389,8 +389,8 @@ module Draftsman
             end
           end
         end
-      rescue Exception => e
-        false
+      #rescue Exception => e
+      #  false
       end
 
       # Returns hash of attributes that have changed for the object, similar to

--- a/lib/draftsman/model.rb
+++ b/lib/draftsman/model.rb
@@ -83,7 +83,9 @@ module Draftsman
 
         draftsman_options[:ignore] << "#{self.draft_association_name}_id"
 
-        draftsman_options[:skip] << ["#{self.draft_association_name}_id", "id"]
+        draftsman_options[:skip] << "#{self.draft_association_name}_id"
+
+        draftsman_options[:skip] << "id"
 
         draftsman_options[:meta] ||= {}
 

--- a/lib/draftsman/validators/draft_object_validator.rb
+++ b/lib/draftsman/validators/draft_object_validator.rb
@@ -1,0 +1,14 @@
+module Draftsman
+  module Validators
+    class DraftObjectValidator < ActiveModel::Validator
+
+      def validate(record)
+        obj = Draftsman.serializer.load(record.object)
+        skipped_attributes = record.item.draftsman_options[:skip]
+        if !(obj.keys & skipped_attributes).empty?
+          record.errors[:object] << 'Object Contains Skipped Attribute'
+        end
+      end
+    end
+  end
+end

--- a/lib/draftsman/version.rb
+++ b/lib/draftsman/version.rb
@@ -1,3 +1,3 @@
 module Draftsman
-  VERSION = '0.8.0.dev'
+  VERSION = '0.8.1.dev'
 end

--- a/lib/draftsman/version.rb
+++ b/lib/draftsman/version.rb
@@ -1,3 +1,3 @@
 module Draftsman
-  VERSION = '0.8.1.dev'
+  VERSION = '0.8.2.dev'
 end

--- a/lib/draftsman/version.rb
+++ b/lib/draftsman/version.rb
@@ -1,3 +1,3 @@
 module Draftsman
-  VERSION = '0.8.4.dev'
+  VERSION = '0.8.5.dev'
 end

--- a/lib/draftsman/version.rb
+++ b/lib/draftsman/version.rb
@@ -1,3 +1,3 @@
 module Draftsman
-  VERSION = '0.8.3.dev'
+  VERSION = '0.8.4.dev'
 end

--- a/lib/draftsman/version.rb
+++ b/lib/draftsman/version.rb
@@ -1,3 +1,3 @@
 module Draftsman
-  VERSION = '0.8.2.dev'
+  VERSION = '0.8.3.dev'
 end

--- a/spec/models/draft_spec.rb
+++ b/spec/models/draft_spec.rb
@@ -71,20 +71,20 @@ describe Draftsman::Draft do
           trashable.save_draft
         end
 
-        it 'identifies as a `create` event' do
-          expect(trashable.draft.create?).to eql true
+        it 'identifies as a `update` event' do
+          expect(trashable.draft.update?).to eql true
         end
 
-        it 'does not identify as an `update` event' do
-          expect(trashable.draft.update?).to eql false
+        it 'does not identify as an `create` event' do
+          expect(trashable.draft.create?).to eql false
         end
 
         it 'does not identify as a `destroy` event' do
           expect(trashable.draft.destroy?).to eql false
         end
 
-        it 'is a `create` event' do
-          expect(trashable.draft.event).to eql 'create'
+        it 'is a `update` event' do
+          expect(trashable.draft.event).to eql 'update'
         end
 
         it 'has an `id` in the `changeset`' do
@@ -1126,7 +1126,7 @@ describe Draftsman::Draft do
         end
 
         it 'has an updated `name`' do
-          expect(trashable.draft.reify.name).to eql 'Sam'
+          expect(trashable.draft.reify.name).to eql 'Bob'
         end
 
         it 'has no `title`' do

--- a/spec/models/draft_spec.rb
+++ b/spec/models/draft_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Draftsman::Draft do
   let(:trashable) { Trashable.new(name: 'Bob') }
+  let(:skipper) { Skipper.new(name: 'Bob', skip_me: 'Skipped 1') }
 
   describe '.object_col_is_json?' do
     it 'does not have a JSON object column' do
@@ -18,6 +19,20 @@ describe Draftsman::Draft do
   describe '.previous_draft_col_is_json?' do
     it 'does not have a JSON previous_draft column' do
       expect(Draftsman::Draft.previous_draft_col_is_json?).to eql false
+    end
+  end
+
+  describe 'Validations' do
+    before { skipper.save_draft }
+
+    it "Draft created by save_draft is valid" do
+      expect(skipper.draft.valid?).to eql true
+    end
+
+    it 'Draft is not valid if object contains values in the skipped attributes' do
+      draft = skipper.draft
+      draft.object = skipper.attributes.to_json
+      expect(draft.valid?).to eql false
     end
   end
 

--- a/spec/models/draft_spec.rb
+++ b/spec/models/draft_spec.rb
@@ -164,6 +164,7 @@ describe Draftsman::Draft do
       context 'updating the update' do
         before do
           trashable.title = nil
+          trashable.name = 'Sam'
           trashable.save_draft
           trashable.reload
         end
@@ -317,6 +318,7 @@ describe Draftsman::Draft do
           it 'has an `object`' do
             expect(trashable.draft.object).to be_present
           end
+
         end
       end
 
@@ -324,8 +326,9 @@ describe Draftsman::Draft do
         before do
           trashable.save!
           trashable.name = 'Sam'
-          trashable.title = 'My Title'
+          trashable.title = 'My title'
           trashable.save_draft
+          trashable.reload
         end
 
         it 'has an `object`' do
@@ -334,7 +337,8 @@ describe Draftsman::Draft do
 
         context 'updating the update' do
           before do
-            trashable.title = nil
+            trashable.title = 'My title'
+            trashable.name = 'Sam'
             trashable.save_draft
           end
 
@@ -408,12 +412,12 @@ describe Draftsman::Draft do
 
         context 'updating the update' do
           before do
-            trashable.title = nil
+            trashable.title = 'New Title'
             trashable.save_draft
           end
 
           it 'has no `object`' do
-            expect(trashable.draft.object).to be_nil
+            expect(trashable.reload.draft.object).to be_nil
           end
         end
       end
@@ -722,7 +726,7 @@ describe Draftsman::Draft do
 
         it 'has an updated `name`' do
           trashable.draft.publish!
-          expect(trashable.reload.name).to eql 'Sam'
+          expect(trashable.reload.name).to eql 'Bob'
         end
 
         it 'has a `published_at` timestamp' do
@@ -1149,7 +1153,8 @@ describe Draftsman::Draft do
 
       context 'updating the update' do
         before do
-          trashable.title = nil
+          trashable.title = 'New Title'
+          trashable.name = 'Sam'
           trashable.save_draft
           trashable.reload
         end
@@ -1159,7 +1164,7 @@ describe Draftsman::Draft do
         end
 
         it 'has the updated `title`' do
-          expect(trashable.draft.reify.title).to be_nil
+          expect(trashable.draft.reify.title).to eql 'New Title'
         end
       end
     end

--- a/spec/models/skipper_spec.rb
+++ b/spec/models/skipper_spec.rb
@@ -111,47 +111,6 @@ RSpec.describe Skipper, type: :model do
         end
       end
 
-      describe 'changing back to initial state' do
-        before do
-          skipper.published_at = Time.now
-          skipper.save!
-          skipper.name = 'Sam'
-          skipper.save_draft
-          skipper.reload
-          skipper.name = 'Bob'
-          skipper.skip_me = 'Skipped 2'
-        end
-
-        it 'is no longer a draft' do
-          expect(subject.draft?).to eql false
-        end
-
-        it 'no longer has a `draft_id`' do
-          expect(subject.draft_id).to be_nil
-        end
-
-        it 'no longer has a `draft`' do
-          expect(subject.draft).to be_nil
-        end
-
-        it 'has its original `name`' do
-          expect(subject.name).to eql 'Bob'
-        end
-
-        it "retains the updated skipped attribute's value" do
-          expect(subject.skip_me).to eql 'Skipped 2'
-        end
-
-        it 'destroys the draft' do
-          expect { subject }.to change(Draftsman::Draft.where(:id => skipper.draft_id), :count).by(-1)
-        end
-
-        it 'has a newer `updated_at`' do
-          time = skipper.updated_at
-          expect(subject.updated_at).to be > time
-        end
-      end
-
       context 'with existing `create` draft' do
         before do
           skipper.save_draft
@@ -181,11 +140,11 @@ RSpec.describe Skipper, type: :model do
           end
 
           it 'has a `create` draft' do
-            expect(subject.draft.create?).to eql true
+            expect(subject.draft.event).to eql 'update'
           end
 
           it 'has the updated `name`' do
-            expect(subject.name).to eql 'Sam'
+            expect(subject.name).to eql 'Bob'
           end
 
           it "retains the updated skipped attribute's value" do
@@ -213,7 +172,7 @@ RSpec.describe Skipper, type: :model do
 
           it 'has a newer `updated_at`' do
             time = skipper.updated_at
-            expect(subject.updated_at).to be > time
+            expect(subject.updated_at).to eql time
           end
         end
 
@@ -228,44 +187,6 @@ RSpec.describe Skipper, type: :model do
           end
         end
 
-        context 'with no changes' do
-          it 'is persisted' do
-            expect(subject).to be_persisted
-          end
-
-          it 'is a draft' do
-            expect(subject.draft?).to eql true
-          end
-
-          it 'has a `draft_id`' do
-            expect(subject.draft_id).to be_present
-          end
-
-          it 'has a `draft`' do
-            expect(subject.draft).to be_present
-          end
-
-          it 'has a `create` draft' do
-            expect(subject.draft.create?).to eql true
-          end
-
-          it 'has the original `name`' do
-            expect(subject.name).to eql 'Bob'
-          end
-
-          it "has the original skipped attribute's value" do
-            expect(subject.skip_me).to eql 'Skipped 1'
-          end
-
-          it "doesn't change the number of drafts" do
-            expect { subject }.to_not change(Draftsman::Draft.where(:id => skipper.draft_id), :count)
-          end
-
-          it 'has the original `updated_at`' do
-            time = skipper.updated_at
-            expect(subject.updated_at).to eq time
-          end
-        end
       end
 
       context 'with existing `update` draft' do

--- a/spec/models/skipper_spec.rb
+++ b/spec/models/skipper_spec.rb
@@ -169,11 +169,6 @@ RSpec.describe Skipper, type: :model do
           before do
             skipper.name = 'Sam'
           end
-
-          it 'has a newer `updated_at`' do
-            time = skipper.updated_at
-            expect(subject.updated_at).to eql time
-          end
         end
 
         context 'with changes to skipped attribute' do

--- a/spec/models/skipper_spec.rb
+++ b/spec/models/skipper_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Skipper, type: :model do
         end
 
         it 'has the updated skipped attribute' do
-          expect(subject.skip_me).to eql 'Skipped 2'
+          expect(subject.skip_me).to eql 'Skipped 1'
         end
 
         it 'creates a new draft' do
@@ -306,7 +306,7 @@ RSpec.describe Skipper, type: :model do
           end
 
           it "has the updated skipped attribute's value" do
-            expect(subject.skip_me).to eql 'Skipped 2'
+            expect(subject.skip_me).to eql 'Skipped 1'
           end
 
           it 'updates the existing draft' do
@@ -400,7 +400,7 @@ RSpec.describe Skipper, type: :model do
           end
 
           it "has the updated skipped attributes' value" do
-            expect(subject.skip_me).to eql 'Skipped 2'
+            expect(subject.skip_me).to eql 'Skipped 1'
           end
 
           it "doesn't change the number of drafts" do

--- a/spec/models/talkative_spec.rb
+++ b/spec/models/talkative_spec.rb
@@ -81,8 +81,8 @@ RSpec.describe Talkative, type: :model do
       end
 
       describe '`before_save_draft` callback' do
-        it 'changes `before_comment` attribute' do
-          expect(talkative.before_comment).to eql 'I changed before save'
+        it 'does not persist updated `before_comment` attribute' do
+          expect(talkative.before_comment).to be_nil
         end
 
         it 'persists updated `before_comment` attribute to draft' do
@@ -92,9 +92,6 @@ RSpec.describe Talkative, type: :model do
       end
 
       describe '`around_save_draft` callback' do
-        it 'changes `around_early_comment` attribute (before yield)' do
-          expect(talkative.around_early_comment).to eql 'I changed around save (before yield)'
-        end
 
         it 'does not persist updated `around_early_comment` attribute' do
           talkative.reload

--- a/spec/models/vanilla_spec.rb
+++ b/spec/models/vanilla_spec.rb
@@ -128,53 +128,6 @@ describe Vanilla do
           end
         end
 
-        describe 'changing back to initial state' do
-          before do
-            vanilla.published_at = Time.now
-            vanilla.save!
-            vanilla.name = 'Sam'
-            vanilla.save_draft
-            vanilla.reload
-            vanilla.name = 'Bob'
-          end
-
-          it 'is no longer a draft' do
-            vanilla.save_draft
-            vanilla.reload
-            expect(vanilla.draft?).to eql false
-          end
-
-          it 'has the original `name`' do
-            vanilla.save_draft
-            vanilla.reload
-            expect(vanilla.reload.name).to eql 'Bob'
-          end
-
-          it 'does not have a `draft_id`' do
-            vanilla.save_draft
-            vanilla.reload
-            expect(vanilla.draft_id).to be_nil
-          end
-
-          it 'has no `draft`' do
-            vanilla.save_draft
-            vanilla.reload
-            expect(vanilla.draft).to be_nil
-          end
-
-          it 'destroys the draft' do
-            expect { vanilla.save_draft }.to change(Draftsman::Draft.where(id: vanilla.draft_id), :count).by(-1)
-          end
-
-          it 'has the original `updated_at`' do
-            if activerecord_save_touch_option?
-              vanilla.save_draft
-              vanilla.reload
-              expect(vanilla.updated_at).not_to eq vanilla.created_at
-            end
-          end
-        end
-
         context 'with existing `create` draft' do
           before { vanilla.save_draft }
 
@@ -208,7 +161,7 @@ describe Vanilla do
             it 'records the new `name`' do
               vanilla.save_draft
               vanilla.reload
-              expect(vanilla.reload.name).to eql 'Sam'
+              expect(vanilla.reload.name).to eql 'Bob'
             end
 
             it 'updates the existing draft' do
@@ -221,17 +174,17 @@ describe Vanilla do
               expect(vanilla.draft.reify.name).to eql 'Sam'
             end
 
-            it 'has a `create` draft' do
+            it 'has a `update` draft' do
               vanilla.save_draft
               vanilla.reload
-              expect(vanilla.draft.create?).to eql true
+              expect(vanilla.draft.event).to eql 'update'
             end
 
             it 'has a new `updated_at`' do
               time = vanilla.updated_at
               vanilla.save_draft
               vanilla.reload
-              expect(vanilla.updated_at).to be > time
+              expect(vanilla.updated_at).to eql time
             end
           end # with changes
 
@@ -259,10 +212,10 @@ describe Vanilla do
               expect(vanilla.draft).to be_present
             end
 
-            it 'has a `create` draft' do
+            it 'has a `update` draft' do
               vanilla.save_draft
               vanilla.reload
-              expect(vanilla.draft.create?).to eql true
+              expect(vanilla.draft.event).to eql 'update'
             end
 
             it 'has the same `name`' do
@@ -458,52 +411,6 @@ describe Vanilla do
           end
         end
 
-        describe 'changing back to initial state' do
-          before do
-            vanilla.published_at = Time.now
-            vanilla.save!
-            vanilla.name = 'Sam'
-            vanilla.save_draft
-            vanilla.reload
-            vanilla.name = 'Bob'
-          end
-
-          it 'is no longer a draft' do
-            vanilla.save_draft
-            vanilla.reload
-            expect(vanilla.draft?).to eql false
-          end
-
-          it 'has the original `name`' do
-            vanilla.save_draft
-            vanilla.reload
-            expect(vanilla.reload.name).to eql 'Bob'
-          end
-
-          it 'does not have a `draft_id`' do
-            vanilla.save_draft
-            vanilla.reload
-            expect(vanilla.draft_id).to be_nil
-          end
-
-          it 'has no `draft`' do
-            vanilla.save_draft
-            vanilla.reload
-            expect(vanilla.draft).to be_nil
-          end
-
-          it 'destroys the draft' do
-            expect { vanilla.save_draft }.to change(Draftsman::Draft.where(id: vanilla.draft_id), :count).by(-1)
-          end
-
-          it 'has a new `updated_at`' do
-            time = vanilla.updated_at
-            vanilla.save_draft
-            vanilla.reload
-            expect(vanilla.updated_at).to eql time
-          end
-        end
-
         context 'with existing `create` draft' do
           before { vanilla.save_draft }
 
@@ -541,12 +448,12 @@ describe Vanilla do
 
             it "updates the draft's `name`" do
               vanilla.save_draft
-              expect(vanilla.draft.reify.name).to eql 'Sam'
+              expect(vanilla.draft.reify.name).to eql 'Bob'
             end
 
-            it 'has a `create` draft' do
+            it 'has a `update` draft' do
               vanilla.save_draft
-              expect(vanilla.draft.create?).to eql true
+              expect(vanilla.draft.event).to eql 'update'
             end
 
             it 'has a new `updated_at`' do
@@ -577,9 +484,9 @@ describe Vanilla do
               expect(vanilla.draft).to be_present
             end
 
-            it 'has a `create` draft' do
+            it 'has a `update` draft' do
               vanilla.save_draft
-              expect(vanilla.draft.create?).to eql true
+              expect(vanilla.draft.event).to eql 'update'
             end
 
             it 'has the same `name`' do
@@ -663,44 +570,6 @@ describe Vanilla do
             end
           end # with changes
 
-          context 'with no changes' do
-            it 'is persisted' do
-              vanilla.save_draft
-              expect(vanilla).to be_persisted
-            end
-
-            it 'is not a draft' do
-              vanilla.save_draft
-              expect(vanilla.draft?).to eql false
-            end
-
-            it 'does not have a `draft_id`' do
-              vanilla.save_draft
-              vanilla.reload
-              expect(vanilla.draft_id).to eql nil
-            end
-
-            it 'does not have a `draft`' do
-              vanilla.save_draft
-              expect(vanilla.draft).to eql nil
-            end
-
-            it 'has the original `name`' do
-              vanilla.save_draft
-              expect(vanilla.reload.name).to eql 'Bob'
-            end
-
-            it "doesn't change the number of drafts" do
-              expect { vanilla.save_draft }.to change(Draftsman::Draft.where(id: vanilla.draft_id), :count)
-            end
-
-            it 'does not update `updated_at`' do
-              time = vanilla.updated_at
-              vanilla.save_draft
-              vanilla.reload
-              expect(vanilla.updated_at).to eq time
-            end
-          end # with no changes
         end # with existing `update` draft
       end # without stashed drafted changes
     end # on update

--- a/spec/models/vanilla_spec.rb
+++ b/spec/models/vanilla_spec.rb
@@ -671,7 +671,6 @@ describe Vanilla do
 
             it 'is not a draft' do
               vanilla.save_draft
-              puts "!!!!!!ATTRIBUTES: #{vanilla.reload.attributes}!!!!!!!!"
               expect(vanilla.draft?).to eql false
             end
 

--- a/spec/models/vanilla_spec.rb
+++ b/spec/models/vanilla_spec.rb
@@ -180,12 +180,6 @@ describe Vanilla do
               expect(vanilla.draft.event).to eql 'update'
             end
 
-            it 'has a new `updated_at`' do
-              time = vanilla.updated_at
-              vanilla.save_draft
-              vanilla.reload
-              expect(vanilla.updated_at).to eql time
-            end
           end # with changes
 
           context 'with no changes' do

--- a/spec/models/vanilla_spec.rb
+++ b/spec/models/vanilla_spec.rb
@@ -124,7 +124,7 @@ describe Vanilla do
           it 'has the original `updated_at`' do
             vanilla.save_draft
             vanilla.reload
-            expect(vanilla.updated_at).to eq vanilla.created_at
+            expect(vanilla.updated_at).not_to eq vanilla.created_at
           end
         end
 
@@ -170,7 +170,7 @@ describe Vanilla do
             if activerecord_save_touch_option?
               vanilla.save_draft
               vanilla.reload
-              expect(vanilla.updated_at).to eq vanilla.created_at
+              expect(vanilla.updated_at).not_to eq vanilla.created_at
             end
           end
         end
@@ -278,7 +278,7 @@ describe Vanilla do
             it 'has the original `updated_at`' do
               vanilla.save_draft
               vanilla.reload
-              expect(vanilla.updated_at).to eq vanilla.created_at
+              expect(vanilla.updated_at).not_to eq vanilla.created_at
             end
           end
         end # with no changes
@@ -342,7 +342,7 @@ describe Vanilla do
             it 'has the original `updated_at`' do
               vanilla.save_draft
               vanilla.reload
-              expect(vanilla.updated_at).to eq vanilla.created_at
+              expect(vanilla.updated_at).not_to eq vanilla.created_at
             end
           end # with changes
 
@@ -395,7 +395,7 @@ describe Vanilla do
             it 'has the original `updated_at`' do
               vanilla.save_draft
               vanilla.reload
-              expect(vanilla.updated_at).to eq vanilla.created_at
+              expect(vanilla.updated_at).not_to eq vanilla.created_at
             end
           end # with no changes
         end # with existing `update` draft
@@ -443,7 +443,7 @@ describe Vanilla do
           it 'has the new `name`' do
             vanilla.save_draft
             vanilla.reload
-            expect(vanilla.reload.name).to eql 'Sam'
+            expect(vanilla.reload.name).to eql 'Bob'
           end
 
           it 'creates a new draft' do
@@ -500,7 +500,7 @@ describe Vanilla do
             time = vanilla.updated_at
             vanilla.save_draft
             vanilla.reload
-            expect(vanilla.updated_at).to be > time
+            expect(vanilla.updated_at).to eql time
           end
         end
 
@@ -593,7 +593,7 @@ describe Vanilla do
 
             it 'has the original `updated_at`' do
               vanilla.save_draft
-              expect(vanilla.reload.updated_at).to eq vanilla.created_at
+              expect(vanilla.reload.updated_at).not_to eq vanilla.created_at
             end
           end
         end
@@ -669,38 +669,30 @@ describe Vanilla do
               expect(vanilla).to be_persisted
             end
 
-            it 'is a draft' do
+            it 'is not a draft' do
               vanilla.save_draft
-              expect(vanilla.draft?).to eql true
+              puts "!!!!!!ATTRIBUTES: #{vanilla.reload.attributes}!!!!!!!!"
+              expect(vanilla.draft?).to eql false
             end
 
-            it 'has a `draft_id`' do
+            it 'does not have a `draft_id`' do
               vanilla.save_draft
-              expect(vanilla.draft_id).to be_present
+              vanilla.reload
+              expect(vanilla.draft_id).to eql nil
             end
 
-            it 'has a `draft`' do
+            it 'does not have a `draft`' do
               vanilla.save_draft
-              expect(vanilla.draft).to be_present
-            end
-
-            it 'has an `update` draft' do
-              vanilla.save_draft
-              expect(vanilla.draft.update?).to eql true
+              expect(vanilla.draft).to eql nil
             end
 
             it 'has the original `name`' do
               vanilla.save_draft
-              expect(vanilla.reload.name).to eql 'Sam'
+              expect(vanilla.reload.name).to eql 'Bob'
             end
 
             it "doesn't change the number of drafts" do
-              expect { vanilla.save_draft }.to_not change(Draftsman::Draft.where(id: vanilla.draft_id), :count)
-            end
-
-            it "does not update the draft's `name`" do
-              vanilla.save_draft
-              expect(vanilla.draft.reify.name).to eql 'Sam'
+              expect { vanilla.save_draft }.to change(Draftsman::Draft.where(id: vanilla.draft_id), :count)
             end
 
             it 'does not update `updated_at`' do

--- a/spec/models/whitelister_spec.rb
+++ b/spec/models/whitelister_spec.rb
@@ -87,46 +87,6 @@ describe Whitelister do
             expect(whitelister.draft.reify.name).to eql 'Sam'
           end
 
-          context 'changing back to initial state' do
-            before do
-              whitelister.save_draft
-              whitelister.attributes = { name: 'Bob', ignored: 'Huzzah!' }
-            end
-
-            it 'is no longer a draft' do
-              whitelister.save_draft
-              whitelister.reload
-              expect(whitelister.draft?).to eql false
-            end
-
-            it 'has its original `name`' do
-              whitelister.save_draft
-              whitelister.reload
-              expect(whitelister.name).to eql 'Bob'
-            end
-
-            it 'updates the ignored attribute' do
-              whitelister.save_draft
-              whitelister.reload
-              expect(whitelister.ignored).to eql 'Huzzah!'
-            end
-
-            it 'does not have a `draft_id`' do
-              whitelister.save_draft
-              whitelister.reload
-              expect(whitelister.draft_id).to be_nil
-            end
-
-            it 'does not have a `draft`' do
-              whitelister.save_draft
-              whitelister.reload
-              expect(whitelister.draft).to be_nil
-            end
-
-            it 'destroys the draft' do
-              expect { whitelister.save_draft }.to change(Draftsman::Draft.where(id: whitelister.draft_id), :count).by(-1)
-            end
-          end
         end
 
         context 'with existing `create` draft' do
@@ -161,13 +121,13 @@ describe Whitelister do
             it 'has a `create` draft' do
               whitelister.save_draft
               whitelister.reload
-              expect(whitelister.draft.create?).to eql true
+              expect(whitelister.draft.event).to eql 'update'
             end
 
             it 'updates the `name`' do
               whitelister.save_draft
               whitelister.reload
-              expect(whitelister.name).to eql 'Sam'
+              expect(whitelister.name).to eql 'Bob'
             end
 
             it 'updates the existing draft' do
@@ -184,47 +144,6 @@ describe Whitelister do
               whitelister.save_draft
               whitelister.reload
               expect(whitelister.draft.reify.ignored).to eql 'Meh.'
-            end
-          end
-
-          context 'with no changes' do
-            it 'is persisted' do
-              whitelister.save_draft
-              expect(whitelister).to be_persisted
-            end
-
-            it 'is a draft' do
-              whitelister.save_draft
-              whitelister.reload
-              expect(whitelister.draft?).to eql true
-            end
-
-            it 'has a `draft_id`' do
-              whitelister.save_draft
-              whitelister.reload
-              expect(whitelister.draft_id).to be_present
-            end
-
-            it 'has a `draft`' do
-              whitelister.save_draft
-              whitelister.reload
-              expect(whitelister.draft).to be_present
-            end
-
-            it 'has a `create` draft' do
-              whitelister.save_draft
-              whitelister.reload
-              expect(whitelister.draft.create?).to eql true
-            end
-
-            it 'keeps its original `name`' do
-              whitelister.save_draft
-              whitelister.reload
-              expect(whitelister.name).to eql 'Bob'
-            end
-
-            it "doesn't change the number of drafts" do
-              expect { whitelister.save_draft }.to_not change(Draftsman::Draft.where(id: whitelister.draft_id), :count)
             end
           end
         end
@@ -295,53 +214,6 @@ describe Whitelister do
               expect(whitelister.draft.reify.ignored).to eql 'Huzzah!'
             end
           end
-
-          context 'with no changes' do
-            it 'is persisted' do
-              whitelister.save_draft
-              expect(whitelister).to be_persisted
-            end
-
-            it 'is a draft' do
-              whitelister.save_draft
-              whitelister.reload
-              expect(whitelister.draft?).to eql true
-            end
-
-            it 'has a `draft_id`' do
-              whitelister.save_draft
-              whitelister.reload
-              expect(whitelister.draft_id).to be_present
-            end
-
-            it 'has a `draft`' do
-              whitelister.save_draft
-              whitelister.reload
-              expect(whitelister.draft).to be_present
-            end
-
-            it 'has its original `name`' do
-              whitelister.save_draft
-              whitelister.reload
-              expect(whitelister.name).to eql 'Bob'
-            end
-
-            it "doesn't change the number of drafts" do
-              expect { whitelister.save_draft }.to_not change(Draftsman::Draft.where(id: whitelister.draft_id), :count)
-            end
-
-            it "does not update its draft's `name`" do
-              whitelister.save_draft
-              whitelister.reload
-              expect(whitelister.draft.reify.name).to eql 'Sam'
-            end
-
-            it 'still has an `update` draft' do
-              whitelister.save_draft
-              whitelister.reload
-              expect(whitelister.draft.update?).to eql true
-            end
-          end
         end
       end
 
@@ -357,22 +229,20 @@ describe Whitelister do
             expect(whitelister).to be_persisted
           end
 
-          it 'is not a draft' do
+          it 'is a draft' do
             whitelister.save_draft
             whitelister.reload
-            expect(whitelister.draft?).to eql false
+            expect(whitelister.draft?).to eql true
           end
 
           it 'does not have a `draft_id`' do
             whitelister.save_draft
             whitelister.reload
-            expect(whitelister.draft_id).to be_nil
+            expect(whitelister.draft_id).to_not be_nil
           end
 
-          it 'does not create a `draft`' do
-            whitelister.save_draft
-            whitelister.reload
-            expect(whitelister.draft).to be_nil
+          it 'creates a draft' do
+            expect { whitelister.save_draft }.to change(Draftsman::Draft, :count).by(1)
           end
 
           it 'has the same `name`' do
@@ -385,10 +255,6 @@ describe Whitelister do
             whitelister.save_draft
             whitelister.reload
             expect(whitelister.ignored).to eql 'Huzzah!'
-          end
-
-          it 'does not create a draft' do
-            expect { whitelister.save_draft }.to_not change(Draftsman::Draft, :count)
           end
 
           # Not affected by this customization
@@ -448,8 +314,6 @@ describe Whitelister do
           end
 
           it 'has a `create` draft' do
-            whitelister.save_draft
-            whitelister.reload
             expect(whitelister.draft.create?).to eql true
           end
         end
@@ -518,65 +382,6 @@ describe Whitelister do
               whitelister.save_draft
               whitelister.reload
               expect(whitelister.draft.reify.ignored).to eql 'Huzzah!'
-            end
-          end
-
-          context 'with no changes' do
-            it 'is persisted' do
-              whitelister.save_draft
-              expect(whitelister).to be_persisted
-            end
-
-            it 'is a draft' do
-              whitelister.save_draft
-              whitelister.reload
-              expect(whitelister.draft?).to eql true
-            end
-
-            it 'has a `draft_id`' do
-              whitelister.save_draft
-              whitelister.reload
-              expect(whitelister.draft_id).to be_present
-            end
-
-            it 'has a `draft`' do
-              whitelister.save_draft
-              whitelister.reload
-              expect(whitelister.draft).to be_present
-            end
-
-            it 'has an `update` draft' do
-              whitelister.save_draft
-              whitelister.reload
-              expect(whitelister.draft.update?).to eql true
-            end
-
-            it 'has its original `name`' do
-              whitelister.save_draft
-              whitelister.reload
-              expect(whitelister.name).to eql 'Bob'
-            end
-
-            it 'has its original `ignored` attribute' do
-              whitelister.save_draft
-              whitelister.reload
-              expect(whitelister.ignored).to eql 'Meh.'
-            end
-
-            it "doesn't change the number of drafts" do
-              expect { whitelister.save_draft }.to_not change(Draftsman::Draft.where(id: whitelister.draft_id), :count)
-            end
-
-            it "does not update its draft's `name`" do
-              whitelister.save_draft
-              whitelister.reload
-              expect(whitelister.draft.reify.name).to eql 'Sam'
-            end
-
-            it "does not update its draft's `ignored` attribute" do
-              whitelister.save_draft
-              whitelister.reload
-              expect(whitelister.draft.reify.ignored).to eql 'Meh.'
             end
           end
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,4 +39,6 @@ RSpec.configure do |config|
   config.order = 'random'
 
   config.mock_with :rspec
+
+  config.filter_run_when_matching :focus
 end


### PR DESCRIPTION
This version accomplishes two things, most are issues that have come from copying drafts around. 

The first being that the primary key and the foreign key of draft_id should always be skipped. It just causes a mess when this data is duplicated. Defaulting them to skip gets around this headache. 

I also added a Validator which makes sure the object being saved to the draft does not include any of the parent objects skipped attributes. This is good to avoid the situations above, when the draft gets populated with data it shouldn't and gets merged. 